### PR TITLE
denis: add support for recovering non-concrete models

### DIFF
--- a/denis/__init__.py
+++ b/denis/__init__.py
@@ -31,18 +31,36 @@ class Denis(object):
         objects = self.collect()
         obj_per_model = {}
         models = []
+        non_concrete_models = set()
 
         for obj in objects:
             model_name = obj._meta.model_name
+            if obj._meta.concrete_model in non_concrete_models:
+                continue
             if model_name not in obj_per_model:
+                # we cannot bulk_create multi-table inherited models
+                non_concrete_parents = [
+                    parent for parent in obj._meta.get_parent_list()
+                        if parent._meta.concrete_model is not obj._meta.concrete_model
+                ]
+                for parent in non_concrete_parents:
+                    non_concrete_models.add(parent)
                 obj_per_model[model_name] = {
                     'class': type(obj),
-                    'objs': []
+                    'non_concrete_parents': non_concrete_parents,
+                    'objs': [],
                 }
                 models.append(model_name)
             obj_per_model[model_name]['objs'].append(obj)
 
-        for model in models:
+        # remove models that are parent of others
+        concrete_models = (m for m in models if m not in non_concrete_models)
+        for model in concrete_models:
             m = obj_per_model[model]
             klass = m['class']
-            klass.objects.using(using).bulk_create(m['objs'])
+            # we cannot bulk_create multi-table inherited models, for other use plain save
+            if not m['non_concrete_parents']:
+                klass.objects.using(using).bulk_create(m['objs'])
+            else:
+                for obj in m['objs']:
+                    obj.save(using=using)


### PR DESCRIPTION
We cannot use bulk_create for multi-table models but we can use
plain save.
Then we need to keep track of models with non concrete parents and
avoid creating them.